### PR TITLE
Refresh tournament pages for mobile theming

### DIFF
--- a/src/app/api/admin/build-doubles/route.ts
+++ b/src/app/api/admin/build-doubles/route.ts
@@ -82,8 +82,9 @@ export async function POST(req: Request) {
     if (insErr) return NextResponse.json({ error: insErr.message }, { status: 400 });
 
     return NextResponse.json({ ok: true, message: 'Doubles created: 2 SF + Final.' });
-  } catch (e: any) {
-    if (e instanceof Response) return e; // 403 from requireAdminPin
-    return NextResponse.json({ error: e?.message ?? 'Server error' }, { status: 500 });
+  } catch (error: unknown) {
+    if (error instanceof Response) return error; // 403 from requireAdminPin
+    const message = error instanceof Error ? error.message : 'Server error';
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/src/app/api/admin/build-singles/route.ts
+++ b/src/app/api/admin/build-singles/route.ts
@@ -166,8 +166,9 @@ export async function POST(req: Request) {
     }
 
     return NextResponse.json({ ok: true, message: 'R1 ensured (or created), QF/SF/F ensured, R1 wired.' });
-  } catch (e: any) {
-    if (e instanceof Response) return e; // 403 from requireAdminPin
-    return NextResponse.json({ error: e?.message ?? 'Server error' }, { status: 500 });
+  } catch (error: unknown) {
+    if (error instanceof Response) return error; // 403 from requireAdminPin
+    const message = error instanceof Error ? error.message : 'Server error';
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/src/app/api/admin/clear-result/route.ts
+++ b/src/app/api/admin/clear-result/route.ts
@@ -50,8 +50,9 @@ export async function POST(req: Request) {
 
     await supabaseAdmin.from('matches').update({ winner: null }).eq('id', m.id);
     return NextResponse.json({ ok: true });
-  } catch (e: any) {
-    if (e instanceof Response) return e;
-    return NextResponse.json({ error: e?.message ?? 'Server error' }, { status: 500 });
+  } catch (error: unknown) {
+    if (error instanceof Response) return error;
+    const message = error instanceof Error ? error.message : 'Server error';
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/src/app/api/admin/players/delete/route.ts
+++ b/src/app/api/admin/players/delete/route.ts
@@ -12,8 +12,9 @@ export async function POST(req: Request) {
     if (error) return NextResponse.json({ error: error.message }, { status: 400 });
 
     return NextResponse.json({ ok: true });
-  } catch (e: any) {
-    if (e instanceof Response) return e;
-    return NextResponse.json({ error: e?.message ?? 'Server error' }, { status: 500 });
+  } catch (error: unknown) {
+    if (error instanceof Response) return error;
+    const message = error instanceof Error ? error.message : 'Server error';
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/src/app/api/admin/players/update/route.ts
+++ b/src/app/api/admin/players/update/route.ts
@@ -15,7 +15,7 @@ export async function POST(req: Request) {
     if (!ev?.id) return NextResponse.json({ error: 'No event found' }, { status: 400 });
     const eventId = ev.id as string;
 
-    const patch: any = {};
+    const patch: { name?: string; seed?: number } = {};
     if (typeof name === 'string' && name.trim()) patch.name = name.trim();
     if (seed != null) {
       if (!Number.isInteger(seed) || seed < 1 || seed > 16)
@@ -33,8 +33,9 @@ export async function POST(req: Request) {
     if (updErr) return NextResponse.json({ error: updErr.message }, { status: 400 });
 
     return NextResponse.json({ ok: true });
-  } catch (e: any) {
-    if (e instanceof Response) return e;
-    return NextResponse.json({ error: e?.message ?? 'Server error' }, { status: 500 });
+  } catch (error: unknown) {
+    if (error instanceof Response) return error;
+    const message = error instanceof Error ? error.message : 'Server error';
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/src/app/api/admin/reset/route.ts
+++ b/src/app/api/admin/reset/route.ts
@@ -74,8 +74,9 @@ export async function POST(req: Request) {
     if (insErr) return NextResponse.json({ error: insErr.message }, { status: 400 });
 
     return NextResponse.json({ ok: true, message: 'Matches cleared and R1 regenerated.' });
-  } catch (e: any) {
-    if (e instanceof Response) return e; // 403 from requireAdminPin
-    return NextResponse.json({ error: e?.message ?? 'Server error' }, { status: 500 });
+  } catch (error: unknown) {
+    if (error instanceof Response) return error; // 403 from requireAdminPin
+    const message = error instanceof Error ? error.message : 'Server error';
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/src/app/api/admin/set-winner/route.ts
+++ b/src/app/api/admin/set-winner/route.ts
@@ -70,8 +70,9 @@ export async function POST(req: Request) {
     await placeTeam(m.feeds_loser_to,  loserTeam);
 
     return NextResponse.json({ ok: true });
-  } catch (e: any) {
-    if (e instanceof Response) return e; // 403 from requireAdminPin
-    return NextResponse.json({ error: e?.message ?? 'Server error' }, { status: 500 });
+  } catch (error: unknown) {
+    if (error instanceof Response) return error; // 403 from requireAdminPin
+    const message = error instanceof Error ? error.message : 'Server error';
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/src/app/control/page.tsx
+++ b/src/app/control/page.tsx
@@ -1,92 +1,134 @@
-// src/app/control/page.tsx
-'use client';
+"use client";
 
-import { useEffect, useState } from 'react';
-import { supabase } from '@/lib/supabaseClient';
-import { ensurePin, adminFetch } from '@/lib/adminClient';
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { ensurePin, adminFetch } from "@/lib/adminClient";
+import { supabase } from "@/lib/supabaseClient";
 
 type Status = {
-  // totals
   players: number;
   r1: number;
   qfMain: number;
   qfLower: number;
-  doubles: number;        // all doubles matches (SF + F)
+  doubles: number;
+  r1Winners: number;
+  qfMainWinners: number;
+  qfLowerWinners: number;
+  dSF: number;
+  dSFWinners: number;
+  dFinal: number;
+  dFinalWinner: number;
+};
 
-  // winners set
-  r1Winners: number;      // out of 8
-  qfMainWinners: number;  // out of 4
-  qfLowerWinners: number; // out of 4
-  dSF: number;            // doubles SF count (should be 2 when created)
-  dSFWinners: number;     // out of 2
-  dFinal: number;         // 0 or 1
-  dFinalWinner: number;   // 0 or 1
+const INITIAL_STATUS: Status = {
+  players: 0,
+  r1: 0,
+  qfMain: 0,
+  qfLower: 0,
+  doubles: 0,
+  r1Winners: 0,
+  qfMainWinners: 0,
+  qfLowerWinners: 0,
+  dSF: 0,
+  dSFWinners: 0,
+  dFinal: 0,
+  dFinalWinner: 0,
 };
 
 export default function ControlPage() {
-  const [status, setStatus] = useState<Status>({
-    players: 0,
-    r1: 0,
-    qfMain: 0,
-    qfLower: 0,
-    doubles: 0,
-    r1Winners: 0,
-    qfMainWinners: 0,
-    qfLowerWinners: 0,
-    dSF: 0,
-    dSFWinners: 0,
-    dFinal: 0,
-    dFinalWinner: 0,
-  });
+  const [status, setStatus] = useState<Status>(INITIAL_STATUS);
   const [busy, setBusy] = useState(false);
   const [msg, setMsg] = useState<string | null>(null);
 
-  // ---- Status loader (reads via anon key) ----
   async function refreshStatus() {
     try {
-      // latest event id
       const { data: ev } = await supabase
-        .from('events')
-        .select('id')
-        .order('created_at', { ascending: false })
+        .from("events")
+        .select("id")
+        .order("created_at", { ascending: false })
         .limit(1)
         .maybeSingle();
       if (!ev) {
-        setStatus({
-          players: 0, r1: 0, qfMain: 0, qfLower: 0, doubles: 0,
-          r1Winners: 0, qfMainWinners: 0, qfLowerWinners: 0,
-          dSF: 0, dSFWinners: 0, dFinal: 0, dFinalWinner: 0,
-        });
+        setStatus(INITIAL_STATUS);
         return;
       }
       const eventId = ev.id;
 
       const [
         players,
-        r1All,           r1Win,
-        qfMainAll,       qfMainWin,
-        qfLowerAll,      qfLowerWin,
+        r1All,
+        r1Win,
+        qfMainAll,
+        qfMainWin,
+        qfLowerAll,
+        qfLowerWin,
         doublesAll,
-        dSFAll,          dSFWins,
-        dFinalAll,       dFinalWins,
+        dSFAll,
+        dSFWins,
+        dFinalAll,
+        dFinalWins,
       ] = await Promise.all([
-        supabase.from('players').select('id').eq('event_id', eventId),
-        supabase.from('matches').select('id').eq('event_id', eventId).eq('stage', 'R1'),
-        supabase.from('matches').select('id').eq('event_id', eventId).eq('stage', 'R1').not('winner', 'is', null),
-
-        supabase.from('matches').select('id').eq('event_id', eventId).eq('stage', 'QF').eq('bracket', 'MAIN'),
-        supabase.from('matches').select('id').eq('event_id', eventId).eq('stage', 'QF').eq('bracket', 'MAIN').not('winner', 'is', null),
-
-        supabase.from('matches').select('id').eq('event_id', eventId).eq('stage', 'QF').eq('bracket', 'LOWER'),
-        supabase.from('matches').select('id').eq('event_id', eventId).eq('stage', 'QF').eq('bracket', 'LOWER').not('winner', 'is', null),
-
-        supabase.from('matches').select('id').eq('event_id', eventId).eq('bracket', 'DOUBLES'),
-
-        supabase.from('matches').select('id').eq('event_id', eventId).eq('bracket', 'DOUBLES').eq('stage', 'SF'),
-        supabase.from('matches').select('id').eq('event_id', eventId).eq('bracket', 'DOUBLES').eq('stage', 'SF').not('winner', 'is', null),
-
-        supabase.from('matches').select('id').eq('event_id', eventId).eq('bracket', 'DOUBLES').eq('stage', 'F'),
-        supabase.from('matches').select('id').eq('event_id', eventId).eq('bracket', 'DOUBLES').eq('stage', 'F').not('winner', 'is', null),
+        supabase.from("players").select("id").eq("event_id", eventId),
+        supabase.from("matches").select("id").eq("event_id", eventId).eq("stage", "R1"),
+        supabase
+          .from("matches")
+          .select("id")
+          .eq("event_id", eventId)
+          .eq("stage", "R1")
+          .not("winner", "is", null),
+        supabase
+          .from("matches")
+          .select("id")
+          .eq("event_id", eventId)
+          .eq("stage", "QF")
+          .eq("bracket", "MAIN"),
+        supabase
+          .from("matches")
+          .select("id")
+          .eq("event_id", eventId)
+          .eq("stage", "QF")
+          .eq("bracket", "MAIN")
+          .not("winner", "is", null),
+        supabase
+          .from("matches")
+          .select("id")
+          .eq("event_id", eventId)
+          .eq("stage", "QF")
+          .eq("bracket", "LOWER"),
+        supabase
+          .from("matches")
+          .select("id")
+          .eq("event_id", eventId)
+          .eq("stage", "QF")
+          .eq("bracket", "LOWER")
+          .not("winner", "is", null),
+        supabase.from("matches").select("id").eq("event_id", eventId).eq("bracket", "DOUBLES"),
+        supabase
+          .from("matches")
+          .select("id")
+          .eq("event_id", eventId)
+          .eq("bracket", "DOUBLES")
+          .eq("stage", "SF"),
+        supabase
+          .from("matches")
+          .select("id")
+          .eq("event_id", eventId)
+          .eq("bracket", "DOUBLES")
+          .eq("stage", "SF")
+          .not("winner", "is", null),
+        supabase
+          .from("matches")
+          .select("id")
+          .eq("event_id", eventId)
+          .eq("bracket", "DOUBLES")
+          .eq("stage", "F"),
+        supabase
+          .from("matches")
+          .select("id")
+          .eq("event_id", eventId)
+          .eq("bracket", "DOUBLES")
+          .eq("stage", "F")
+          .not("winner", "is", null),
       ]);
 
       setStatus({
@@ -95,40 +137,36 @@ export default function ControlPage() {
         qfMain: qfMainAll.data?.length ?? 0,
         qfLower: qfLowerAll.data?.length ?? 0,
         doubles: doublesAll.data?.length ?? 0,
-
         r1Winners: r1Win.data?.length ?? 0,
         qfMainWinners: qfMainWin.data?.length ?? 0,
         qfLowerWinners: qfLowerWin.data?.length ?? 0,
-
         dSF: dSFAll.data?.length ?? 0,
         dSFWinners: dSFWins.data?.length ?? 0,
         dFinal: dFinalAll.data?.length ?? 0,
         dFinalWinner: dFinalWins.data?.length ?? 0,
       });
     } catch {
-      // non-fatal
+      // non-fatal fetch error
     }
   }
 
   useEffect(() => {
-    refreshStatus();
+    void refreshStatus();
   }, []);
 
-  // ---- Next-action hint ----
   function nextActionHint(s: Status): string {
-    if (s.players !== 16) return 'Add and seed players (need exactly 16 with seeds 1..16).';
-    if (s.r1 < 8) return 'Create Round 1 (use “Reset: Start fresh (R1 only)” or the Singles builder).';
+    if (s.players !== 16) return "Add and seed players (need exactly 16 with seeds 1..16).";
+    if (s.r1 < 8) return "Create Round 1 (use \"Reset: Start fresh (R1 only)\" or the Singles builder).";
     if (s.r1Winners < 8) return `Set winners for Round 1 (${s.r1Winners}/8).`;
-    if (s.qfMain < 4 || s.qfLower < 4) return 'Create 4 QFs per bracket (click the Singles builder).';
+    if (s.qfMain < 4 || s.qfLower < 4) return "Create 4 QFs per bracket (click the Singles builder).";
     if (s.qfMainWinners + s.qfLowerWinners < 8)
       return `Set all 8 QF winners (${s.qfMainWinners + s.qfLowerWinners}/8). This enables Doubles.`;
-    if (s.dSF === 0) return 'Build Doubles (from QF losers).';
+    if (s.dSF === 0) return "Build Doubles (from QF losers).";
     if (s.dSFWinners < 2) return `Set Doubles SF winners (${s.dSFWinners}/2) to populate the Final.`;
-    if (s.dFinal === 1 && s.dFinalWinner === 0) return 'Set the Doubles Final winner to finish the event.';
-    return 'All good. Continue setting winners through to each Final.';
+    if (s.dFinal === 1 && s.dFinalWinner === 0) return "Set the Doubles Final winner to finish the event.";
+    return "All good. Continue setting winners through to each Final.";
   }
 
-  // ---- Button handler helper (write via service routes) ----
   async function action(fn: () => Promise<void>) {
     setBusy(true);
     setMsg(null);
@@ -136,135 +174,174 @@ export default function ControlPage() {
       if (!ensurePin()) return;
       await fn();
       await refreshStatus();
-    } catch (e: any) {
-      setMsg(e?.message ?? 'Action failed');
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : "Action failed";
+      setMsg(message);
     } finally {
       setBusy(false);
     }
   }
 
   return (
-    <main style={{ padding: '2rem', fontFamily: 'Inter, system-ui, sans-serif', maxWidth: 920 }}>
-      <h1>TD Control</h1>
-      <p style={{ marginTop: 4, opacity: 0.8 }}>Admin-only actions (secured by PIN).</p>
-
-      {/* Status banner */}
+    <main className="relative mx-auto flex min-h-[calc(100vh-4rem)] w-full max-w-5xl flex-col gap-10 px-4 py-10 sm:px-6 lg:px-8">
       <div
-        style={{
-          border: '1px solid #ddd',
-          borderRadius: 10,
-          padding: '12px 14px',
-          margin: '16px 0',
-          background: '#f9f9fb',
-          lineHeight: 1.6,
-        }}
-      >
-        <strong>Tournament Status</strong>
-        <div>Players: {status.players} {status.players === 16 ? '✅' : '⚠️'}</div>
+        aria-hidden
+        className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_var(--surface-glow),_transparent_65%)]"
+      />
 
-        <div style={{ marginTop: 6 }}>
-          <em>Singles (DwB Spring Champs + Pudel König)</em>
+      <header className="flex flex-col gap-3 text-center sm:gap-4">
+        <span className="self-center rounded-full border border-[color:var(--border)] bg-[color:var(--highlight)] px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-[color:var(--accent)]">
+          Admin control
+        </span>
+        <h1 className="text-balance text-3xl font-semibold sm:text-4xl">TD Control</h1>
+        <p className="text-pretty text-sm text-[color:var(--muted)] sm:text-base">
+          Quick actions to build brackets, manage doubles, and reset rounds. Designed for pin-protected tournament staff on the go.
+        </p>
+      </header>
+
+      <section className="rounded-3xl border border-[color:var(--border)] bg-[color:var(--card)] p-6 shadow-sm sm:p-8">
+        <h2 className="text-lg font-semibold">Tournament status</h2>
+        <p className="mt-1 text-sm text-[color:var(--muted)]">
+          Snapshot of your event progress with guidance on what to do next.
+        </p>
+
+        <div className="mt-6 grid gap-4 sm:grid-cols-2">
+          <div className="rounded-2xl border border-[color:var(--border)] bg-[color:var(--highlight)] p-4">
+            <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-[color:var(--muted)]">Singles</h3>
+            <dl className="mt-3 space-y-2 text-sm">
+              <div className="flex items-center justify-between">
+                <dt className="text-[color:var(--muted)]">Players seeded</dt>
+                <dd className="font-semibold text-[color:var(--foreground)]">{status.players}/16</dd>
+              </div>
+              <div className="flex items-center justify-between">
+                <dt className="text-[color:var(--muted)]">Round 1 created</dt>
+                <dd className="font-semibold text-[color:var(--foreground)]">{status.r1}/8</dd>
+              </div>
+              <div className="flex items-center justify-between">
+                <dt className="text-[color:var(--muted)]">Round 1 winners</dt>
+                <dd className="font-semibold text-[color:var(--foreground)]">{status.r1Winners}/8</dd>
+              </div>
+              <div className="flex items-center justify-between">
+                <dt className="text-[color:var(--muted)]">Main QF created</dt>
+                <dd className="font-semibold text-[color:var(--foreground)]">{status.qfMain}/4</dd>
+              </div>
+              <div className="flex items-center justify-between">
+                <dt className="text-[color:var(--muted)]">Lower QF created</dt>
+                <dd className="font-semibold text-[color:var(--foreground)]">{status.qfLower}/4</dd>
+              </div>
+              <div className="flex items-center justify-between">
+                <dt className="text-[color:var(--muted)]">QF winners set</dt>
+                <dd className="font-semibold text-[color:var(--foreground)]">{status.qfMainWinners + status.qfLowerWinners}/8</dd>
+              </div>
+            </dl>
+          </div>
+
+          <div className="rounded-2xl border border-[color:var(--border)] bg-[color:var(--highlight)] p-4">
+            <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-[color:var(--muted)]">Doubles</h3>
+            <dl className="mt-3 space-y-2 text-sm">
+              <div className="flex items-center justify-between">
+                <dt className="text-[color:var(--muted)]">Matches created</dt>
+                <dd className="font-semibold text-[color:var(--foreground)]">{status.doubles}</dd>
+              </div>
+              <div className="flex items-center justify-between">
+                <dt className="text-[color:var(--muted)]">SF slots</dt>
+                <dd className="font-semibold text-[color:var(--foreground)]">{status.dSF}/2</dd>
+              </div>
+              <div className="flex items-center justify-between">
+                <dt className="text-[color:var(--muted)]">SF winners</dt>
+                <dd className="font-semibold text-[color:var(--foreground)]">{status.dSFWinners}/2</dd>
+              </div>
+              <div className="flex items-center justify-between">
+                <dt className="text-[color:var(--muted)]">Final created</dt>
+                <dd className="font-semibold text-[color:var(--foreground)]">{status.dFinal}/1</dd>
+              </div>
+              <div className="flex items-center justify-between">
+                <dt className="text-[color:var(--muted)]">Final winner</dt>
+                <dd className="font-semibold text-[color:var(--foreground)]">{status.dFinalWinner}/1</dd>
+              </div>
+            </dl>
+          </div>
         </div>
-        <div>R1 matches: {status.r1} {status.r1 === 8 ? '✅' : '⚠️'} — Winners set: {status.r1Winners}/8</div>
-        <div>QF (Main): {status.qfMain} {status.qfMain === 4 ? '✅' : '⚠️'} — Winners set: {status.qfMainWinners}/4</div>
-        <div>QF (Lower): {status.qfLower} {status.qfLower === 4 ? '✅' : '⚠️'} — Winners set: {status.qfLowerWinners}/4</div>
 
-        <div style={{ marginTop: 6 }}>
-          <em>Doubles (Anthony Prangley Silence of the Champs)</em>
+        <div className="mt-6 rounded-2xl border border-dashed border-[color:var(--border)] bg-[color:var(--background)]/70 p-4 text-sm text-[color:var(--muted)]">
+          <strong className="font-semibold text-[color:var(--foreground)]">Next action:</strong> {nextActionHint(status)}
         </div>
-        <div>SF created: {status.dSF}/2 — SF winners: {status.dSFWinners}/2</div>
-        <div>Final created: {status.dFinal}/1 — Final winner set: {status.dFinalWinner}/1</div>
+      </section>
 
-        <div style={{ marginTop: 10, paddingTop: 8, borderTop: '1px dashed #ddd' }}>
-          <strong>Next action:</strong> {nextActionHint(status)}
+      <section className="rounded-3xl border border-[color:var(--border)] bg-[color:var(--card)] p-6 shadow-sm sm:p-8">
+        <h2 className="text-lg font-semibold">Quick actions</h2>
+        <p className="mt-1 text-sm text-[color:var(--muted)]">
+          These endpoints update live data. You will be prompted for the admin PIN before continuing.
+        </p>
+        <div className="mt-6 grid gap-3 sm:grid-cols-2">
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() =>
+              action(async () => {
+                const res = await adminFetch<{ message?: string }>("/api/admin/build-singles", {});
+                setMsg(res?.message ?? "Singles wired.");
+              })
+            }
+            className="rounded-2xl border border-[color:var(--accent)] bg-[color:var(--accent)] px-4 py-3 text-sm font-semibold text-[color:var(--accent-contrast)] shadow transition hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--background)] disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {busy ? "Working…" : "Create 4 QFs per bracket & wire R1"}
+          </button>
+
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() =>
+              action(async () => {
+                const res = await adminFetch<{ message?: string }>("/api/admin/build-doubles", {});
+                setMsg(res?.message ?? "Doubles created.");
+              })
+            }
+            className="rounded-2xl border border-blue-900 bg-blue-900 px-4 py-3 text-sm font-semibold text-white shadow transition hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--background)] disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {busy ? "Working…" : "Build Doubles (from QF losers)"}
+          </button>
+
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() =>
+              action(async () => {
+                const res = await adminFetch<{ message?: string }>("/api/admin/reset", { action: "matches_only" });
+                setMsg(res?.message ?? "All matches cleared.");
+              })
+            }
+            className="rounded-2xl border border-red-600 bg-transparent px-4 py-3 text-sm font-semibold text-red-600 shadow transition hover:bg-red-600/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-600 focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--background)] disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {busy ? "Working…" : "Reset: Clear ALL matches"}
+          </button>
+
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() =>
+              action(async () => {
+                const res = await adminFetch<{ message?: string }>("/api/admin/reset", { action: "regen_r1" });
+                setMsg(res?.message ?? "Cleared + regenerated R1.");
+              })
+            }
+            className="rounded-2xl border border-[color:var(--accent)] bg-[color:var(--accent)] px-4 py-3 text-sm font-semibold text-[color:var(--accent-contrast)] shadow transition hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--background)] disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {busy ? "Working…" : "Reset: Start fresh (R1 only)"}
+          </button>
         </div>
-      </div>
 
-      {/* Actions */}
-      <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
-        <button
-          onClick={() =>
-            action(async () => {
-              const res = await adminFetch('/api/admin/build-singles', {});
-              setMsg(res?.message ?? 'Singles wired.');
-            })
-          }
-          disabled={busy}
-          style={{
-            padding: '10px 14px',
-            borderRadius: 8,
-            border: '1px solid #000',
-            background: '#000',
-            color: '#fff',
-          }}
-        >
-          {busy ? 'Working…' : 'Create 4 QFs per bracket & wire R1'}
-        </button>
+        {msg && (
+          <p className="mt-4 rounded-2xl border border-[color:var(--border)] bg-[color:var(--highlight)] px-4 py-3 text-sm text-[color:var(--muted)]">
+            {msg}
+          </p>
+        )}
+      </section>
 
-        <button
-          onClick={() =>
-            action(async () => {
-              const res = await adminFetch('/api/admin/build-doubles', {});
-              setMsg(res?.message ?? 'Doubles created.');
-            })
-          }
-          disabled={busy}
-          style={{
-            padding: '10px 14px',
-            borderRadius: 8,
-            border: '1px solid #003',
-            background: '#003',
-            color: '#fff',
-          }}
-        >
-          {busy ? 'Working…' : 'Build Doubles (from QF losers)'}
-        </button>
-
-        <button
-          onClick={() =>
-            action(async () => {
-              const res = await adminFetch('/api/admin/reset', { action: 'matches_only' });
-              setMsg(res?.message ?? 'All matches cleared.');
-            })
-          }
-          disabled={busy}
-          style={{
-            padding: '10px 14px',
-            borderRadius: 8,
-            border: '1px solid #900',
-            background: '#fff',
-            color: '#900',
-          }}
-        >
-          {busy ? 'Working…' : 'Reset: Clear ALL matches'}
-        </button>
-
-        <button
-          onClick={() =>
-            action(async () => {
-              const res = await adminFetch('/api/admin/reset', { action: 'regen_r1' });
-              setMsg(res?.message ?? 'Cleared + regenerated R1.');
-            })
-          }
-          disabled={busy}
-          style={{
-            padding: '10px 14px',
-            borderRadius: 8,
-            border: '1px solid #000',
-            background: '#000',
-            color: '#fff',
-          }}
-        >
-          {busy ? 'Working…' : 'Reset: Start fresh (R1 only)'}
-        </button>
-      </div>
-
-      {msg && <p style={{ marginTop: 12 }}>{msg}</p>}
-
-      <p style={{ marginTop: 18, opacity: 0.7 }}>
-        Manage players on <a href="/players" style={{ textDecoration: 'underline' }}>Players</a>.
-        Set winners on the <a href="/matches" style={{ textDecoration: 'underline' }}>Matches</a> page.
-        View the public tree on <a href="/brackets" style={{ textDecoration: 'underline' }}>Brackets</a>.
+      <p className="text-center text-sm text-[color:var(--muted)]">
+        Manage players on <Link href="/players" className="underline">Players</Link>. Set winners on the {" "}
+        <Link href="/matches" className="underline">Matches</Link> page. View the public tree on {" "}
+        <Link href="/brackets" className="underline">Brackets</Link>.
       </p>
     </main>
   );

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12,6 +12,9 @@
   --muted: #666666;
   --highlight: #f9fafb; /* subtle alt background */
 
+  /* Accent glow for backgrounds */
+  --surface-glow: rgba(79, 70, 229, 0.08);
+
   --accent: #111111;          /* dark text / primary */
   --accent-contrast: #ffffff; /* text on accent */
 }
@@ -34,6 +37,8 @@
     --muted: #9ca3af;
     --highlight: #131417;
 
+    --surface-glow: rgba(99, 102, 241, 0.24);
+
     --accent: #f3f4f6;
     --accent-contrast: #111111;
   }
@@ -46,6 +51,7 @@ html, body {
   font-family: var(--font-sans), Arial, Helvetica, sans-serif;
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
+  min-height: 100%;
 }
 
 /* Links inherit color by default */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,7 +12,7 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
-const inter = Inter({ subsets: ['latin'] });
+const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
   title: 'Dinner with the Bishop',
@@ -22,7 +22,11 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body className={inter.className}>{children}</body>
+      <body
+        className={`${geistSans.variable} ${geistMono.variable} ${inter.className} bg-[var(--background)] text-[var(--foreground)] antialiased`}
+      >
+        {children}
+      </body>
     </html>
   );
 }

--- a/src/app/matches/page.tsx
+++ b/src/app/matches/page.tsx
@@ -1,19 +1,21 @@
-'use client';
+"use client";
 
-import { useEffect, useMemo, useState } from 'react';
-import { supabase } from '@/lib/supabaseClient';
-import { adminFetch, ensurePin } from '@/lib/adminClient';
+import { useEffect, useMemo, useState } from "react";
+import { adminFetch, ensurePin } from "@/lib/adminClient";
+import { supabase } from "@/lib/supabaseClient";
 
+type Bracket = "MAIN" | "LOWER" | "DOUBLES";
+type Stage = "R1" | "QF" | "SF" | "F";
 
 type MatchRow = {
   id: string;
   event_id: string;
-  bracket: 'MAIN' | 'LOWER' | 'DOUBLES';
-  stage: 'R1' | 'QF' | 'SF' | 'F';
+  bracket: Bracket;
+  stage: Stage;
   round_num: number;
   team_a: string[];
   team_b: string[];
-  winner: 'A' | 'B' | null;
+  winner: "A" | "B" | null;
   feeds_winner_to: string | null;
   feeds_loser_to: string | null;
   is_doubles: boolean;
@@ -21,25 +23,31 @@ type MatchRow = {
 
 type Player = { id: string; name: string; seed: number | null };
 
-const BRACKET_TITLES: Record<'MAIN'|'LOWER'|'DOUBLES', string> = {
-  MAIN: 'DwB Spring Champs',
-  LOWER: 'Pudel König',
-  DOUBLES: 'Anthony Prangley Silence of the Champs',
+const BRACKET_TITLES: Record<Bracket, string> = {
+  MAIN: "DwB Spring Champs",
+  LOWER: "Pudel König",
+  DOUBLES: "Anthony Prangley Silence of the Champs",
 };
 
+const STAGE_LABEL: Record<Stage, string> = {
+  R1: "Round 1",
+  QF: "Quarterfinals",
+  SF: "Semifinals",
+  F: "Final",
+};
 
-const arraysEqual = (x: string[] = [], y: string[] = []) =>
-  x.length === y.length && x.every((id, i) => id === y[i]);
+const STAGE_ORDER: Stage[] = ["R1", "QF", "SF", "F"];
+const BRACKET_ORDER: Bracket[] = ["MAIN", "LOWER", "DOUBLES"];
 
 async function getLatestEventId(): Promise<string | null> {
   const { data, error } = await supabase
-    .from('events')
-    .select('id')
-    .order('created_at', { ascending: false })
+    .from("events")
+    .select("id")
+    .order("created_at", { ascending: false })
     .limit(1)
     .single();
   if (error) {
-    console.error('events load error:', error);
+    console.error("events load error:", error);
     return null;
   }
   return data?.id ?? null;
@@ -53,310 +61,343 @@ export default function MatchesPage() {
   const [err, setErr] = useState<string | null>(null);
 
   const [editingId, setEditingId] = useState<string | null>(null);
-  const [winner, setWinner] = useState<'A' | 'B' | ''>('');
+  const [winner, setWinner] = useState<"A" | "B" | "">("");
 
   const nameById = useMemo(() => {
-    const m = new Map<string, string>();
-    players.forEach((p) => m.set(p.id, p.name));
-    return m;
+    const map = new Map<string, string>();
+    players.forEach((player) => map.set(player.id, player.name));
+    return map;
   }, [players]);
+
+  async function refreshMatches(currentEventId: string | null) {
+    if (!currentEventId) return;
+    const { data, error } = await supabase
+      .from("matches")
+      .select(
+        "id,event_id,bracket,stage,round_num,team_a,team_b,winner,feeds_winner_to,feeds_loser_to,is_doubles"
+      )
+      .eq("event_id", currentEventId)
+      .order("round_num", { ascending: true });
+    if (error) {
+      throw error;
+    }
+    setMatches(data ?? []);
+  }
 
   useEffect(() => {
     (async () => {
       setLoading(true);
       setErr(null);
-      const eId = await getLatestEventId();
-      if (!eId) {
-        setErr('No event found. Create one in Supabase (table: events).');
+      const latestEventId = await getLatestEventId();
+      if (!latestEventId) {
+        setErr("No event found. Create one in Supabase (table: events).");
         setLoading(false);
         return;
       }
-      setEventId(eId);
+      setEventId(latestEventId);
 
-      const [pRes, mRes] = await Promise.all([
-        supabase.from('players').select('id,name,seed').eq('event_id', eId),
+      const [playersResponse, matchesResponse] = await Promise.all([
+        supabase.from("players").select("id,name,seed").eq("event_id", latestEventId),
         supabase
-          .from('matches')
+          .from("matches")
           .select(
-            'id,event_id,bracket,stage,round_num,team_a,team_b,winner,feeds_winner_to,feeds_loser_to,is_doubles'
+            "id,event_id,bracket,stage,round_num,team_a,team_b,winner,feeds_winner_to,feeds_loser_to,is_doubles"
           )
-          .eq('event_id', eId)
-          .order('round_num', { ascending: true })
+          .eq("event_id", latestEventId)
+          .order("round_num", { ascending: true }),
       ]);
 
-      if (pRes.error) {
-        console.error(pRes.error);
-        setErr(pRes.error.message ?? 'Failed to load players');
+      if (playersResponse.error) {
+        console.error(playersResponse.error);
+        setErr(playersResponse.error.message ?? "Failed to load players");
         setLoading(false);
         return;
       }
-      if (mRes.error) {
-        console.error(mRes.error);
-        setErr(mRes.error.message ?? 'Failed to load matches');
+      if (matchesResponse.error) {
+        console.error(matchesResponse.error);
+        setErr(matchesResponse.error.message ?? "Failed to load matches");
         setLoading(false);
         return;
       }
 
-      setPlayers(pRes.data ?? []);
-      setMatches(mRes.data ?? []);
+      setPlayers(playersResponse.data ?? []);
+      setMatches(matchesResponse.data ?? []);
       setLoading(false);
     })();
   }, []);
 
   function playerLabel(ids: string[]) {
-    if (!ids || ids.length === 0) return '(TBD)';
+    if (!ids || ids.length === 0) return "(TBD)";
     if (ids.length === 1) return nameById.get(ids[0]) ?? ids[0];
-    return ids.map((id) => nameById.get(id) ?? id).join(' + ');
+    return ids.map((id) => nameById.get(id) ?? id).join(" + ");
   }
 
-  function grouped() {
-    const orderStage: Record<MatchRow['stage'], number> = { R1: 1, QF: 2, SF: 3, F: 4 };
-    const stageGroups: Record<string, MatchRow[]> = {};
-    for (const m of matches) {
-      const key = `${m.stage}-${m.bracket}`;
-      stageGroups[key] = stageGroups[key] ?? [];
-      stageGroups[key].push(m);
-    }
-    const keys = Object.keys(stageGroups).sort((a, b) => {
-      const [sa] = a.split('-') as [MatchRow['stage'], string];
-      const [sb] = b.split('-') as [MatchRow['stage'], string];
-      return orderStage[sa] - orderStage[sb] || a.localeCompare(b);
+  const grouped = useMemo(() => {
+    const base = BRACKET_ORDER.reduce(
+      (acc, bracket) => ({
+        ...acc,
+        [bracket]: STAGE_ORDER.reduce(
+          (stageMap, stage) => ({
+            ...stageMap,
+            [stage]: [] as MatchRow[],
+          }),
+          {} as Record<Stage, MatchRow[]>
+        ),
+      }),
+      {} as Record<Bracket, Record<Stage, MatchRow[]>>
+    );
+
+    matches.forEach((match) => {
+      base[match.bracket][match.stage].push(match);
     });
-    return keys.map((k) => ({ key: k, rows: stageGroups[k] }));
+
+    BRACKET_ORDER.forEach((bracket) => {
+      STAGE_ORDER.forEach((stage) => {
+        base[bracket][stage].sort((a, b) => {
+          const roundDelta = (a.round_num ?? 0) - (b.round_num ?? 0);
+          if (roundDelta !== 0) return roundDelta;
+          return a.id.localeCompare(b.id);
+        });
+      });
+    });
+
+    return base;
+  }, [matches]);
+
+  function openEdit(match: MatchRow) {
+    setEditingId(match.id);
+    setWinner((match.winner ?? "") as "A" | "B" | "");
   }
-
-  function openEdit(m: MatchRow) {
-    setEditingId(m.id);
-    setWinner((m.winner as any) ?? '');
-  }
-
-  async function applyAdvance(fromMatch: MatchRow, winnerSide: 'A' | 'B') {
-    // 1) Update current match with winner
-    const { error: uErr } = await supabase
-      .from('matches')
-      .update({ winner: winnerSide })
-      .eq('id', fromMatch.id);
-    if (uErr) throw uErr;
-
-    // Helper: put ENTIRE team (array) into next match's first empty slot
-    async function placeTeamInto(nextId: string | null, team: string[] | null) {
-    if (!nextId || !team || team.length === 0) return;
-
-    const { data: nm, error: nmErr } = await supabase
-        .from('matches')
-        .select('id,team_a,team_b')
-        .eq('id', nextId)
-        .maybeSingle();
-    if (nmErr) throw nmErr;
-    if (!nm) return;
-
-    const a: string[] = nm.team_a ?? [];
-    const b: string[] = nm.team_b ?? [];
-
-    const eq = (x: string[], y: string[]) =>
-        x.length === y.length && x.every((id, i) => id === y[i]);
-    const hasAny = (x: string[], y: string[]) => x.some((id) => y.includes(id));
-
-    // Already exactly placed?
-    if (eq(a, team) || eq(b, team)) return;
-
-    // If a slot contains part of this team (e.g., [p1]), expand it to full team ([p1,p2])
-    if (hasAny(a, team) && a.length < team.length) {
-        const { error } = await supabase.from('matches').update({ team_a: team }).eq('id', nm.id);
-        if (error) throw error;
-        return;
-    }
-    if (hasAny(b, team) && b.length < team.length) {
-        const { error } = await supabase.from('matches').update({ team_b: team }).eq('id', nm.id);
-        if (error) throw error;
-        return;
-    }
-
-    // Otherwise, place into the first empty slot
-    if (a.length === 0) {
-        const { error } = await supabase.from('matches').update({ team_a: team }).eq('id', nm.id);
-        if (error) throw error;
-        return;
-    }
-    if (b.length === 0) {
-        const { error } = await supabase.from('matches').update({ team_b: team }).eq('id', nm.id);
-        if (error) throw error;
-        return;
-    }
-
-    // Both slots filled with other players → do nothing (guard against accidental overwrite)
-    }
-
-    // Build winner/loser TEAMS (arrays). For singles, arrays of length 1. For doubles, both IDs.
-    const teamA = Array.isArray(fromMatch.team_a) ? fromMatch.team_a : [];
-    const teamB = Array.isArray(fromMatch.team_b) ? fromMatch.team_b : [];
-    const winnerTeam = winnerSide === 'A' ? teamA : teamB;
-    const loserTeam  = winnerSide === 'A' ? teamB : teamA;
-
-    // 2) Advance winner team
-    await placeTeamInto(fromMatch.feeds_winner_to, winnerTeam);
-    // 3) Advance loser team (used for R1 → LOWER QF; harmless elsewhere)
-    await placeTeamInto(fromMatch.feeds_loser_to, loserTeam);
-    }
-
-  async function removeTeamFrom(nextId: string | null, team: string[] | null) {
-    if (!nextId || !team || team.length === 0) return;
-
-    // Load the next match (need winner to guard)
-    const { data: nm, error: nmErr } = await supabase
-        .from('matches')
-        .select('id, team_a, team_b, winner')
-        .eq('id', nextId)
-        .maybeSingle();
-    if (nmErr || !nm) return;
-
-    // If downstream match already has a winner, do not modify it
-    if (nm.winner) return;
-
-    const a: string[] = nm.team_a ?? [];
-    const b: string[] = nm.team_b ?? [];
-
-    // Only clear if the slot exactly matches the team we placed
-    if (arraysEqual(a, team)) {
-        await supabase.from('matches').update({ team_a: [] }).eq('id', nm.id);
-    } else if (arraysEqual(b, team)) {
-        await supabase.from('matches').update({ team_b: [] }).eq('id', nm.id);
-    }
-  }
-
-  async function clearResult(matchId: string) {
-    // Load fresh copy (we need winner & teams & feeds)
-    const { data: m, error } = await supabase
-        .from('matches')
-        .select('id, team_a, team_b, winner, feeds_winner_to, feeds_loser_to')
-        .eq('id', matchId)
-        .maybeSingle();
-    if (error || !m) {
-        alert('Could not load match to clear.');
-        return;
-    }
-
-    // If no winner set, nothing to clear
-    if (!m.winner) {
-        // Still try to remove any accidental downstream placements of these teams
-        await removeTeamFrom(m.feeds_winner_to, m.team_a);
-        await removeTeamFrom(m.feeds_winner_to, m.team_b);
-        await removeTeamFrom(m.feeds_loser_to,  m.team_a);
-        await removeTeamFrom(m.feeds_loser_to,  m.team_b);
-        return;
-    }
-
-    // Determine which team advanced where, then clear downstream, then clear winner on this match
-    const teamA: string[] = Array.isArray(m.team_a) ? m.team_a : [];
-    const teamB: string[] = Array.isArray(m.team_b) ? m.team_b : [];
-    const winnerTeam = m.winner === 'A' ? teamA : teamB;
-    const loserTeam  = m.winner === 'A' ? teamB : teamA;
-
-    // Remove teams we placed into next matches (only if those next matches don’t have a winner)
-    await removeTeamFrom(m.feeds_winner_to, winnerTeam);
-    await removeTeamFrom(m.feeds_loser_to,  loserTeam);
-
-    // Finally, clear this match’s winner
-    const { error: uErr } = await supabase
-        .from('matches')
-        .update({ winner: null })
-        .eq('id', m.id);
-    if (uErr) throw uErr;
-    }
 
   async function onSave() {
     if (!editingId) return;
-    if (winner !== 'A' && winner !== 'B') { alert('Pick A or B'); return; }
+    if (winner !== "A" && winner !== "B") {
+      alert("Pick A or B");
+      return;
+    }
     if (!ensurePin()) return;
     try {
-        await adminFetch('/api/admin/set-winner', { matchId: editingId, winner });
-        // reload matches (unchanged fetch below)
-        const { data, error } = await supabase
-        .from('matches')
-        .select('id,event_id,bracket,stage,round_num,team_a,team_b,winner,feeds_winner_to,feeds_loser_to,is_doubles')
-        .eq('event_id', eventId)
-        .order('round_num', { ascending: true });
-        if (error) throw error;
-        setMatches(data ?? []);
-        setEditingId(null);
-        setWinner('');
-    } catch (e: any) {
-        alert(e?.message ?? 'Failed');
+      await adminFetch("/api/admin/set-winner", { matchId: editingId, winner });
+      await refreshMatches(eventId);
+      setEditingId(null);
+      setWinner("");
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : "Failed";
+      alert(message);
     }
   }
 
+  async function onClear(matchId: string) {
+    if (!ensurePin()) return;
+    try {
+      await adminFetch("/api/admin/clear-result", { matchId });
+      await refreshMatches(eventId);
+      setEditingId(null);
+      setWinner("");
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : "Failed to clear";
+      alert(message);
+    }
+  }
 
   return (
-    <main style={{ padding: 24, fontFamily: 'Inter, system-ui, sans-serif' }}>
-      <h1>Matches</h1>
-      {loading && <p>Loading…</p>}
-      {!loading && err && <p style={{ color: 'crimson' }}>{err}</p>}
-      {!loading && !err && grouped().map(({ key, rows }) => {
-        const [stage, bracket] = key.split('-') as [MatchRow['stage'], MatchRow['bracket']];
-        return (
-          <section key={key} style={{ marginBottom: 24 }}>
-            <h2 style={{ margin: '12px 0' }}>{stage} — {BRACKET_TITLES[bracket]}</h2>
-            <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
-              {rows.map((r) => (
-                <li key={r.id} style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '8px 0', borderBottom: '1px solid #eee' }}>
-                  <code style={{ opacity: 0.6 }}>{r.id.slice(0, 8)}</code>
-                  <span style={{ flex: 1 }}>
-                    <strong>A:</strong> {playerLabel(r.team_a)} &nbsp;vs&nbsp; <strong>B:</strong> {playerLabel(r.team_b)}
-                    {r.winner && (
-                      <em style={{ marginLeft: 8, opacity: 0.8 }}>— Winner: {r.winner}</em>
-                    )}
-                  </span>
-                  <button onClick={() => openEdit(r)} style={{ padding: '6px 10px', borderRadius: 6, border: '1px solid #000', background: '#000', color: '#fff' }}>
-                    Set winner
-                  </button>
+    <main className="relative mx-auto flex min-h-[calc(100vh-4rem)] w-full max-w-5xl flex-col gap-10 px-4 py-10 sm:px-6 lg:px-8">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_var(--surface-glow),_transparent_65%)]"
+      />
 
-                  {editingId === r.id && (
-                    <div style={{ display: 'flex', gap: 8, alignItems: 'center', marginLeft: 8 }}>
-                      <label style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-                        <input type="radio" name="winner" value="A" checked={winner === 'A'} onChange={() => setWinner('A')} />
-                        A
-                      </label>
-                      <label style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-                        <input type="radio" name="winner" value="B" checked={winner === 'B'} onChange={() => setWinner('B')} />
-                        B
-                      </label>
-                      <button onClick={onSave} style={{ padding: '6px 10px', borderRadius: 6, border: '1px solid #0a0', background: '#0a0', color: '#fff' }}>
-                        Save
-                      </button>
-                      <button onClick={() => { setEditingId(null); setWinner(''); }} style={{ padding: '6px 10px', borderRadius: 6, border: '1px solid #666', background: '#fff' }}>
-                        Cancel
-                      </button>
-                      <button
-                        onClick={async () => {
-                            if (!ensurePin()) return;
-                            try {
-                                await adminFetch('/api/admin/clear-result', { matchId: r.id });
-                                // reload…
-                                const { data, error } = await supabase
-                                .from('matches')
-                                .select('id,event_id,bracket,stage,round_num,team_a,team_b,winner,feeds_winner_to,feeds_loser_to,is_doubles')
-                                .eq('event_id', eventId)
-                                .order('round_num', { ascending: true });
-                                if (error) throw error;
-                                setMatches(data ?? []);
-                                setEditingId(null);
-                                setWinner('');
-                            } catch (e: any) {
-                                alert(e?.message ?? 'Failed to clear');
-                            }
-                        }}
-                        style={{ padding: '6px 10px', borderRadius: 6, border: '1px solid #c00', background: '#fff', color: '#c00' }}
-                        >
-                        Clear result
-                      </button>
-                    </div>
-                  )}
-                </li>
-              ))}
-            </ul>
-          </section>
-        );
-      })}
+      <header className="flex flex-col gap-3 text-center sm:gap-4">
+        <span className="self-center rounded-full border border-[color:var(--border)] bg-[color:var(--highlight)] px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-[color:var(--accent)]">
+          Match desk
+        </span>
+        <h1 className="text-balance text-3xl font-semibold sm:text-4xl">Matches</h1>
+        <p className="text-pretty text-sm text-[color:var(--muted)] sm:text-base">
+          Update live scores and winners. Mobile-friendly cards keep each round easy to manage from the courtside.
+        </p>
+      </header>
+
+      {loading && (
+        <section className="rounded-3xl border border-[color:var(--border)] bg-[color:var(--card)] p-6 text-center text-sm text-[color:var(--muted)] shadow-sm sm:p-8">
+          Loading the latest event…
+        </section>
+      )}
+
+      {!loading && err && (
+        <section className="rounded-3xl border border-red-500/40 bg-red-500/10 p-6 text-center text-sm font-medium text-red-500 shadow-sm sm:p-8">
+          {err}
+        </section>
+      )}
+
+      {!loading && !err && (
+        <div className="flex flex-col gap-10">
+          {BRACKET_ORDER.map((bracket) => {
+            const rounds = grouped[bracket];
+            const hasMatches = STAGE_ORDER.some((stage) => rounds[stage].length > 0);
+
+            return (
+              <section
+                key={bracket}
+                className="rounded-3xl border border-[color:var(--border)] bg-[color:var(--card)] shadow-sm"
+              >
+                <header className="flex flex-col gap-2 border-b border-[color:var(--border)] px-6 py-6 sm:flex-row sm:items-center sm:justify-between">
+                  <div>
+                    <h2 className="text-lg font-semibold text-[color:var(--foreground)]">{BRACKET_TITLES[bracket]}</h2>
+                    <p className="text-sm text-[color:var(--muted)]">
+                      {bracket === "DOUBLES"
+                        ? "Teams pair up from the singles bracket for a final showdown."
+                        : "Singles bracket seeded from the Players roster."}
+                    </p>
+                  </div>
+                  <span className="text-xs font-semibold uppercase tracking-[0.3em] text-[color:var(--muted)]">
+                    {hasMatches ? "Live rounds" : "No matches"}
+                  </span>
+                </header>
+
+                {hasMatches ? (
+                  <div className="grid gap-6 px-6 py-6 sm:px-8">
+                    {STAGE_ORDER.filter((stage) => rounds[stage].length > 0).map((stage) => (
+                      <div key={stage} className="space-y-4">
+                        <div className="flex items-center justify-between">
+                          <h3 className="text-sm font-semibold uppercase tracking-[0.25em] text-[color:var(--muted)]">
+                            {STAGE_LABEL[stage]}
+                          </h3>
+                          <span className="text-xs text-[color:var(--muted)]">
+                            {rounds[stage].length} match{rounds[stage].length === 1 ? "" : "es"}
+                          </span>
+                        </div>
+                        <div className="grid gap-4">
+                          {rounds[stage].map((match) => {
+                            const isEditing = editingId === match.id;
+                            return (
+                              <article
+                                key={match.id}
+                                className="rounded-2xl border border-[color:var(--border)] bg-[color:var(--background)]/80 p-5 shadow-inner backdrop-blur transition hover:border-[color:var(--accent)]"
+                              >
+                                <div className="flex flex-wrap items-center justify-between gap-3">
+                                  <div className="space-y-1">
+                                    <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[color:var(--muted)]">
+                                      {STAGE_LABEL[match.stage]} · {BRACKET_TITLES[match.bracket]}
+                                    </p>
+                                    <p className="font-mono text-xs text-[color:var(--muted)]">
+                                      {match.id.slice(0, 8)}
+                                    </p>
+                                  </div>
+                                  {match.winner && (
+                                    <span className="inline-flex items-center gap-2 rounded-full border border-[color:var(--border)] bg-[color:var(--highlight)] px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-[color:var(--accent)]">
+                                      Winner · {match.winner}
+                                    </span>
+                                  )}
+                                </div>
+
+                                <div className="mt-4 space-y-3">
+                                  {["A", "B"].map((side) => {
+                                    const label = side === "A" ? playerLabel(match.team_a) : playerLabel(match.team_b);
+                                    const isWinner = match.winner === side;
+                                    return (
+                                      <div
+                                        key={side}
+                                        className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-[color:var(--border)] bg-[color:var(--highlight)] px-3 py-3 text-sm"
+                                      >
+                                        <div className="flex items-center gap-3 text-left">
+                                          <span className="flex h-8 w-8 items-center justify-center rounded-full bg-[color:var(--accent)] text-xs font-semibold text-[color:var(--accent-contrast)]">
+                                            {side}
+                                          </span>
+                                          <span className="text-pretty font-medium text-[color:var(--foreground)]">
+                                            {label}
+                                          </span>
+                                        </div>
+                                        {isWinner && (
+                                          <span className="text-xs font-semibold uppercase tracking-[0.25em] text-[color:var(--accent)]">
+                                            Winner
+                                          </span>
+                                        )}
+                                      </div>
+                                    );
+                                  })}
+                                </div>
+
+                                <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                                  <button
+                                    type="button"
+                                    onClick={() => openEdit(match)}
+                                    className="inline-flex items-center justify-center rounded-xl border border-[color:var(--accent)] px-4 py-2 text-sm font-semibold text-[color:var(--accent)] transition hover:bg-[color:var(--accent)] hover:text-[color:var(--accent-contrast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--background)]"
+                                  >
+                                    {isEditing ? "Editing" : "Set winner"}
+                                  </button>
+
+                                  <button
+                                    type="button"
+                                    onClick={() => onClear(match.id)}
+                                    className="inline-flex items-center justify-center rounded-xl border border-red-500 px-4 py-2 text-sm font-semibold text-red-500 transition hover:bg-red-500/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--background)]"
+                                  >
+                                    Clear result
+                                  </button>
+                                </div>
+
+                                {isEditing && (
+                                  <fieldset className="mt-4 grid gap-3 rounded-2xl border border-[color:var(--border)] bg-[color:var(--highlight)] p-4 text-sm">
+                                    <legend className="text-xs font-semibold uppercase tracking-[0.3em] text-[color:var(--muted)]">
+                                      Choose side
+                                    </legend>
+                                    <label className="flex items-center justify-between gap-3">
+                                      <span className="font-medium text-[color:var(--foreground)]">Team A</span>
+                                      <input
+                                        type="radio"
+                                        name={`winner-${match.id}`}
+                                        value="A"
+                                        checked={winner === "A"}
+                                        onChange={() => setWinner("A")}
+                                      />
+                                    </label>
+                                    <label className="flex items-center justify-between gap-3">
+                                      <span className="font-medium text-[color:var(--foreground)]">Team B</span>
+                                      <input
+                                        type="radio"
+                                        name={`winner-${match.id}`}
+                                        value="B"
+                                        checked={winner === "B"}
+                                        onChange={() => setWinner("B")}
+                                      />
+                                    </label>
+                                    <div className="flex flex-wrap items-center gap-3 pt-2">
+                                      <button
+                                        type="button"
+                                        onClick={onSave}
+                                        className="inline-flex items-center justify-center rounded-xl bg-[color:var(--accent)] px-4 py-2 text-sm font-semibold text-[color:var(--accent-contrast)] shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--background)]"
+                                      >
+                                        Save winner
+                                      </button>
+                                      <button
+                                        type="button"
+                                        onClick={() => {
+                                          setEditingId(null);
+                                          setWinner("");
+                                        }}
+                                        className="inline-flex items-center justify-center rounded-xl border border-[color:var(--border)] px-4 py-2 text-sm font-semibold text-[color:var(--muted)] transition hover:bg-[color:var(--highlight)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--background)]"
+                                      >
+                                        Cancel
+                                      </button>
+                                    </div>
+                                  </fieldset>
+                                )}
+                              </article>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="px-6 py-10 text-center text-sm text-[color:var(--muted)] sm:px-8">
+                    No matches yet. Build brackets from the TD Control page.
+                  </p>
+                )}
+              </section>
+            );
+          })}
+        </div>
+      )}
     </main>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from "react";
 
 export default function HomePage() {
   const [siteUrl, setSiteUrl] = useState("https://dwb-theta.vercel.app"); // fallback
+  const [isDarkMode, setIsDarkMode] = useState(false);
 
   useEffect(() => {
     // Prefer the live origin when client-side
@@ -17,43 +18,140 @@ export default function HomePage() {
     }
   }, []);
 
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+    const handleChange = (event: MediaQueryListEvent) => {
+      setIsDarkMode(event.matches);
+    };
+
+    setIsDarkMode(mediaQuery.matches);
+
+    if (typeof mediaQuery.addEventListener === "function") {
+      mediaQuery.addEventListener("change", handleChange);
+      return () => mediaQuery.removeEventListener("change", handleChange);
+    }
+
+    mediaQuery.addListener(handleChange);
+    return () => mediaQuery.removeListener(handleChange);
+  }, []);
+
   return (
-    <main className="flex flex-col items-center gap-6 p-8 font-sans">
-      <h1 className="text-3xl font-bold text-center">
-        Dinner with the Bishop — Tournament Hub
-      </h1>
-      <p className="text-gray-600 text-center max-w-xl">
-        Welcome! Follow the live tournament brackets, view matches, or manage
-        players if you are the TD (tournament director).
-      </p>
+    <main className="relative mx-auto flex min-h-[calc(100vh-4rem)] w-full max-w-5xl flex-col gap-12 px-6 py-12">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_var(--surface-glow),_transparent_60%)]"
+      />
 
-      <div className="grid gap-4 sm:grid-cols-2 mt-6">
-        <Link href="/brackets" className="rounded-lg border border-gray-300 p-6 hover:bg-gray-50 text-center">
-          <h2 className="text-xl font-semibold">Brackets (public)</h2>
-          <p className="text-gray-500">View live brackets for Main, Lower, and Doubles.</p>
+      <section className="flex flex-col items-center gap-4 text-center sm:gap-6">
+        <span className="rounded-full border border-[color:var(--border)] bg-[color:var(--highlight)] px-4 py-1 text-sm font-medium tracking-wide text-[color:var(--accent)] shadow-sm">
+          Dinner with the Bishop
+        </span>
+        <h1 className="text-balance text-4xl font-bold tracking-tight sm:text-5xl">
+          Tournament Hub
+        </h1>
+        <p className="max-w-2xl text-balance text-lg text-[color:var(--muted)]">
+          Welcome! Follow live brackets, browse match results, or manage player
+          logistics if you are the tournament director.
+        </p>
+      </section>
+
+      <section className="grid gap-4 sm:grid-cols-2">
+        <Link
+          href="/brackets"
+          className="group rounded-2xl border border-[color:var(--border)] bg-[color:var(--card)] p-6 text-center transition-all duration-200 hover:-translate-y-1 hover:border-[color:var(--accent)] hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--background)]"
+        >
+          <h2 className="text-xl font-semibold text-[color:var(--foreground)]">
+            Brackets (public)
+          </h2>
+          <p className="mt-2 text-sm text-[color:var(--muted)]">
+            View live brackets for Main, Lower, and Doubles events.
+          </p>
+          <span className="mt-4 inline-flex items-center justify-center text-sm font-medium text-[color:var(--accent)]">
+            Explore brackets
+            <span aria-hidden className="ml-2 transition-transform group-hover:translate-x-1">
+              →
+            </span>
+          </span>
         </Link>
 
-        <Link href="/matches" className="rounded-lg border border-gray-300 p-6 hover:bg-gray-50 text-center">
-          <h2 className="text-xl font-semibold">Matches (public)</h2>
-          <p className="text-gray-500">Browse all matches and results.</p>
+        <Link
+          href="/matches"
+          className="group rounded-2xl border border-[color:var(--border)] bg-[color:var(--card)] p-6 text-center transition-all duration-200 hover:-translate-y-1 hover:border-[color:var(--accent)] hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--background)]"
+        >
+          <h2 className="text-xl font-semibold text-[color:var(--foreground)]">
+            Matches (public)
+          </h2>
+          <p className="mt-2 text-sm text-[color:var(--muted)]">
+            Browse all matches, final scores, and tables in one view.
+          </p>
+          <span className="mt-4 inline-flex items-center justify-center text-sm font-medium text-[color:var(--accent)]">
+            Dive into results
+            <span aria-hidden className="ml-2 transition-transform group-hover:translate-x-1">
+              →
+            </span>
+          </span>
         </Link>
 
-        <Link href="/players" className="rounded-lg border border-gray-300 p-6 hover:bg-gray-50 text-center">
-          <h2 className="text-xl font-semibold">Players (admin)</h2>
-          <p className="text-gray-500">Manage player list and seeding (PIN required).</p>
+        <Link
+          href="/players"
+          className="group rounded-2xl border border-[color:var(--border)] bg-[color:var(--card)] p-6 text-center transition-all duration-200 hover:-translate-y-1 hover:border-[color:var(--accent)] hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--background)]"
+        >
+          <h2 className="text-xl font-semibold text-[color:var(--foreground)]">
+            Players (admin)
+          </h2>
+          <p className="mt-2 text-sm text-[color:var(--muted)]">
+            Manage the player list, seeding details, and quick updates.
+          </p>
+          <span className="mt-4 inline-flex items-center justify-center text-sm font-medium text-[color:var(--accent)]">
+            Open roster tools
+            <span aria-hidden className="ml-2 transition-transform group-hover:translate-x-1">
+              →
+            </span>
+          </span>
         </Link>
 
-        <Link href="/control" className="rounded-lg border border-gray-300 p-6 hover:bg-gray-50 text-center">
-          <h2 className="text-xl font-semibold">TD Control (admin)</h2>
-          <p className="text-gray-500">Bracket setup, results, and resets (PIN required).</p>
+        <Link
+          href="/control"
+          className="group rounded-2xl border border-[color:var(--border)] bg-[color:var(--card)] p-6 text-center transition-all duration-200 hover:-translate-y-1 hover:border-[color:var(--accent)] hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--background)]"
+        >
+          <h2 className="text-xl font-semibold text-[color:var(--foreground)]">
+            TD Control (admin)
+          </h2>
+          <p className="mt-2 text-sm text-[color:var(--muted)]">
+            Run brackets, post results, and reset rounds with a PIN.
+          </p>
+          <span className="mt-4 inline-flex items-center justify-center text-sm font-medium text-[color:var(--accent)]">
+            Launch control desk
+            <span aria-hidden className="ml-2 transition-transform group-hover:translate-x-1">
+              →
+            </span>
+          </span>
         </Link>
-      </div>
+      </section>
 
-      <div className="mt-10 flex flex-col items-center gap-3">
-        <p className="text-gray-600">Share this QR code to open the tournament hub:</p>
-        <QRCodeCanvas value={siteUrl} size={160} />
-        <p className="text-sm text-gray-500">{siteUrl}</p>
-      </div>
+      <section className="flex flex-col items-center gap-4 rounded-2xl border border-[color:var(--border)] bg-[color:var(--card)] p-6 text-center shadow-sm">
+        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[color:var(--accent)]">
+          Share the hub
+        </p>
+        <p className="max-w-lg text-sm text-[color:var(--muted)]">
+          Post the code at the venue or share with players to give everyone the
+          live tournament dashboard.
+        </p>
+        <div className="rounded-xl border border-[color:var(--border)] bg-[color:var(--highlight)] p-4 shadow-inner">
+          <QRCodeCanvas
+            value={siteUrl}
+            size={168}
+            bgColor={isDarkMode ? "#111214" : "#ffffff"}
+            fgColor={isDarkMode ? "#f4f4f5" : "#1f2937"}
+            includeMargin
+          />
+        </div>
+        <p className="font-mono text-sm text-[color:var(--muted)]">{siteUrl}</p>
+      </section>
     </main>
   );
 }

--- a/src/app/players/add/route.ts
+++ b/src/app/players/add/route.ts
@@ -30,8 +30,9 @@ export async function POST(req: Request) {
     if (insErr) return NextResponse.json({ error: insErr.message }, { status: 400 });
 
     return NextResponse.json({ ok: true });
-  } catch (e: any) {
-    if (e instanceof Response) return e;
-    return NextResponse.json({ error: e?.message ?? 'Server error' }, { status: 500 });
+  } catch (error: unknown) {
+    if (error instanceof Response) return error;
+    const message = error instanceof Error ? error.message : 'Server error';
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/src/app/players/page.tsx
+++ b/src/app/players/page.tsx
@@ -1,75 +1,179 @@
-'use client';
+"use client";
 
-import { useEffect, useState } from 'react';
-import { supabase } from '@/lib/supabaseClient';
-import { ensurePin, adminFetch } from '@/lib/adminClient';
+import { useEffect, useMemo, useState } from "react";
+import { ensurePin, adminFetch } from "@/lib/adminClient";
+import { supabase } from "@/lib/supabaseClient";
 
 type Player = { id: string; name: string; seed: number | null };
 
+const inputClassName =
+  "w-full rounded-xl border border-[color:var(--border)] bg-[color:var(--background)] px-3 py-2 text-sm text-[color:var(--foreground)] shadow-sm transition focus:border-[color:var(--accent)] focus:outline-none focus:ring-2 focus:ring-[color:var(--accent)] focus:ring-offset-2 focus:ring-offset-[color:var(--background)]";
+
 export default function PlayersPage() {
   const [players, setPlayers] = useState<Player[]>([]);
-  const [name, setName] = useState('');
-  const [seed, setSeed] = useState<number | ''>('');
+  const [name, setName] = useState("");
+  const [seed, setSeed] = useState<number | "">("");
   const [msg, setMsg] = useState<string | null>(null);
 
+  const hasRoster = players.length > 0;
+  const sortedPlayers = useMemo(
+    () => [...players].sort((a, b) => (a.seed ?? 0) - (b.seed ?? 0)),
+    [players]
+  );
+
   async function load() {
-    const { data: ev } = await supabase.from('events').select('id').order('created_at', { ascending: false }).limit(1).maybeSingle();
+    const { data: ev } = await supabase
+      .from("events")
+      .select("id")
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
     if (!ev?.id) return;
-    const { data } = await supabase.from('players').select('id,name,seed').eq('event_id', ev.id).order('seed', { ascending: true });
+    const { data } = await supabase
+      .from("players")
+      .select("id,name,seed")
+      .eq("event_id", ev.id)
+      .order("seed", { ascending: true });
     setPlayers(data ?? []);
   }
 
-  useEffect(() => { load(); }, []);
+  useEffect(() => {
+    void load();
+  }, []);
 
   async function addPlayer() {
     if (!ensurePin()) return;
     try {
-      await adminFetch('/api/admin/players/add', { name, seed: Number(seed) });
-      setName(''); setSeed('');
+      await adminFetch("/api/admin/players/add", { name, seed: Number(seed) });
+      setName("");
+      setSeed("");
       await load();
-      setMsg('Player added.');
-    } catch (e: any) {
-      setMsg(`Error: ${e.message}`);
+      setMsg("Player added.");
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      setMsg(`Error: ${message}`);
     }
   }
 
   async function delPlayer(id: string) {
     if (!ensurePin()) return;
     try {
-      await adminFetch('/api/admin/players/delete', { id });
+      await adminFetch("/api/admin/players/delete", { id });
       await load();
-    } catch (e: any) {
-      alert(e.message);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      alert(message);
     }
   }
 
+  const disabledAdd = !name || seed === "";
+
   return (
-    <main style={{ padding: 24, fontFamily: 'Inter, system-ui, sans-serif' }}>
-      <h1>Players</h1>
+    <main className="relative mx-auto flex min-h-[calc(100vh-4rem)] w-full max-w-3xl flex-col gap-8 px-4 py-10 sm:px-6 lg:px-8">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_var(--surface-glow),_transparent_65%)]"
+      />
 
-      {/* Admin add form */}
-      <div style={{ margin: '12px 0', padding: 12, border: '1px solid #ddd', borderRadius: 8 }}>
-        <strong>Add player</strong>
-        <div style={{ display: 'flex', gap: 8, marginTop: 8, alignItems: 'center' }}>
-          <input placeholder="Name" value={name} onChange={(e) => setName(e.target.value)} />
-          <input placeholder="Seed (1..16)" type="number" value={seed} onChange={(e) => setSeed(e.target.value === '' ? '' : Number(e.target.value))} style={{ width: 120 }} />
-          <button onClick={addPlayer} style={{ padding: '6px 10px' }}>Add</button>
+      <header className="flex flex-col gap-3 text-center sm:gap-4">
+        <span className="self-center rounded-full border border-[color:var(--border)] bg-[color:var(--highlight)] px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-[color:var(--accent)]">
+          Admin tools
+        </span>
+        <h1 className="text-balance text-3xl font-semibold sm:text-4xl">Players</h1>
+        <p className="text-pretty text-sm text-[color:var(--muted)] sm:text-base">
+          Curate the singles roster and seeds. All updates sync instantly to the public brackets and matches views.
+        </p>
+      </header>
+
+      <section className="rounded-3xl border border-[color:var(--border)] bg-[color:var(--card)] p-6 shadow-sm sm:p-8">
+        <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+          <h2 className="text-lg font-semibold">Add a player</h2>
+          <p className="text-xs uppercase tracking-[0.3em] text-[color:var(--muted)]">
+            16 total required
+          </p>
         </div>
-        {msg && <div style={{ marginTop: 8, opacity: 0.8 }}>{msg}</div>}
-      </div>
 
-      {/* List */}
-      <ul style={{ listStyle: 'none', padding: 0 }}>
-        {players.map((p) => (
-          <li key={p.id} style={{ display: 'flex', gap: 8, padding: '6px 0', borderBottom: '1px solid #eee' }}>
-            <code style={{ opacity: 0.6, minWidth: 80 }}>#{p.seed}</code>
-            <span style={{ flex: 1 }}>{p.name}</span>
-            <button onClick={() => delPlayer(p.id)} style={{ border: '1px solid #c00', background: '#fff', color: '#c00', borderRadius: 6, padding: '4px 8px' }}>
-              Delete
-            </button>
-          </li>
-        ))}
-      </ul>
+        <div className="mt-4 grid gap-4 sm:grid-cols-[minmax(0,1fr)_minmax(0,150px)_auto] sm:items-end">
+          <label className="flex flex-col gap-2 text-sm">
+            <span className="font-medium text-[color:var(--muted)]">Name</span>
+            <input
+              className={inputClassName}
+              placeholder="Jane Doe"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+            />
+          </label>
+          <label className="flex flex-col gap-2 text-sm">
+            <span className="font-medium text-[color:var(--muted)]">Seed</span>
+            <input
+              className={inputClassName}
+              placeholder="1..16"
+              type="number"
+              inputMode="numeric"
+              value={seed}
+              min={1}
+              max={16}
+              onChange={(event) =>
+                setSeed(event.target.value === "" ? "" : Number(event.target.value))
+              }
+            />
+          </label>
+          <button
+            type="button"
+            onClick={addPlayer}
+            disabled={disabledAdd}
+            className="h-11 rounded-xl bg-[color:var(--accent)] px-4 text-sm font-semibold text-[color:var(--accent-contrast)] shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--background)] disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            Add player
+          </button>
+        </div>
+
+        {msg && (
+          <p className="mt-4 rounded-xl border border-[color:var(--border)] bg-[color:var(--highlight)] px-4 py-2 text-sm text-[color:var(--muted)]">
+            {msg}
+          </p>
+        )}
+      </section>
+
+      <section className="rounded-3xl border border-[color:var(--border)] bg-[color:var(--card)] p-0 shadow-sm">
+        <header className="flex flex-col gap-1 border-b border-[color:var(--border)] px-6 py-5 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h2 className="text-lg font-semibold">Current roster</h2>
+            <p className="text-sm text-[color:var(--muted)]">
+              {hasRoster ? "Tap a seed to make adjustments" : "Add players to build the bracket."}
+            </p>
+          </div>
+          <span className="text-xs font-semibold uppercase tracking-[0.3em] text-[color:var(--muted)]">
+            {players.length}/16
+          </span>
+        </header>
+
+        <ul className="divide-y divide-[color:var(--border)]">
+          {sortedPlayers.map((player) => (
+            <li key={player.id} className="flex flex-col gap-4 px-6 py-4 sm:flex-row sm:items-center sm:gap-6">
+              <span className="inline-flex min-w-[3.5rem] items-center justify-center rounded-full border border-[color:var(--border)] bg-[color:var(--highlight)] px-3 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-[color:var(--accent)]">
+                #{player.seed ?? "—"}
+              </span>
+              <div className="flex-1 text-base font-medium text-[color:var(--foreground)]">
+                {player.name}
+              </div>
+              <button
+                type="button"
+                onClick={() => delPlayer(player.id)}
+                className="inline-flex items-center justify-center rounded-xl border border-red-500 px-4 py-2 text-sm font-semibold text-red-500 transition hover:bg-red-500/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--background)]"
+              >
+                Remove
+              </button>
+            </li>
+          ))}
+
+          {!hasRoster && (
+            <li className="px-6 py-8 text-sm text-[color:var(--muted)]">
+              No players yet. Add names above to seed the draw.
+            </li>
+          )}
+        </ul>
+      </section>
     </main>
   );
 }

--- a/src/lib/adminClient.ts
+++ b/src/lib/adminClient.ts
@@ -1,11 +1,10 @@
-// src/lib/adminClient.ts
-export async function adminFetch(url: string, body: any) {
-  const pin = (typeof window !== 'undefined' && (localStorage.getItem('dwb_admin_pin') || '')) as string;
+export async function adminFetch<T = unknown>(url: string, body: unknown): Promise<T> {
+  const pin = (typeof window !== "undefined" && (localStorage.getItem("dwb_admin_pin") || "")) as string;
   const res = await fetch(url, {
-    method: 'POST',
+    method: "POST",
     headers: {
-      'content-type': 'application/json',
-      'x-admin-pin': pin || '',
+      "content-type": "application/json",
+      "x-admin-pin": pin || "",
     },
     body: JSON.stringify(body),
   });
@@ -13,14 +12,17 @@ export async function adminFetch(url: string, body: any) {
     const txt = await res.text();
     throw new Error(txt || `HTTP ${res.status}`);
   }
-  return res.json();
+  if (res.status === 204) {
+    return undefined as T;
+  }
+  return (await res.json()) as T;
 }
 
 export function ensurePin(): boolean {
-  const current = localStorage.getItem('dwb_admin_pin');
+  const current = localStorage.getItem("dwb_admin_pin");
   if (current) return true;
-  const entered = prompt('Enter admin PIN');
+  const entered = prompt("Enter admin PIN");
   if (!entered) return false;
-  localStorage.setItem('dwb_admin_pin', entered);
+  localStorage.setItem("dwb_admin_pin", entered);
   return true;
 }


### PR DESCRIPTION
## Summary
- restyle the Players admin page with themed cards, responsive form controls, and typed supabase interactions for roster management
- rebuild the Matches workflow with bracket-aware groupings, mobile-friendly match cards, and streamlined winner editing states
- refresh the public Brackets view and TD Control dashboard to match the new design language while standardizing admin API error handling and adminFetch typing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e01daf2f748332bcbad331f5ac6c6e