### PR TITLE
Adjust singles side labels

### DIFF
--- a/src/app/brackets/page.tsx
+++ b/src/app/brackets/page.tsx
@@ -206,26 +206,25 @@ export default function BracketsPage() {
                             )}
                           </div>
                           <div className="mt-3 space-y-2">
-                            <div className={`rounded-xl border px-3 py-3 text-sm font-medium ${
-                              match.winner === "A"
-                                ? "border-[color:var(--accent)] text-[color:var(--foreground)]"
-                                : "border-[color:var(--border)] text-[color:var(--foreground)]"
-                            }`}>
-                              <span className="block text-xs font-semibold uppercase tracking-[0.3em] text-[color:var(--muted)]">
-                                Team A
-                              </span>
-                              <span className="text-pretty">{labelTeam(match.team_a)}</span>
-                            </div>
-                            <div className={`rounded-xl border px-3 py-3 text-sm font-medium ${
-                              match.winner === "B"
-                                ? "border-[color:var(--accent)] text-[color:var(--foreground)]"
-                                : "border-[color:var(--border)] text-[color:var(--foreground)]"
-                            }`}>
-                              <span className="block text-xs font-semibold uppercase tracking-[0.3em] text-[color:var(--muted)]">
-                                Team B
-                              </span>
-                              <span className="text-pretty">{labelTeam(match.team_b)}</span>
-                            </div>
+                            {(["A", "B"] as const).map((side) => {
+                              const isWinner = match.winner === side;
+                              const teamIds = side === "A" ? match.team_a : match.team_b;
+                              return (
+                                <div
+                                  key={side}
+                                  className={`rounded-xl border px-3 py-3 text-sm font-medium ${
+                                    isWinner
+                                      ? "border-[color:var(--accent)] text-[color:var(--foreground)]"
+                                      : "border-[color:var(--border)] text-[color:var(--foreground)]"
+                                  }`}
+                                >
+                                  <span className="block text-xs font-semibold uppercase tracking-[0.3em] text-[color:var(--muted)]">
+                                    {tab === "DOUBLES" ? `Team ${side}` : side}
+                                  </span>
+                                  <span className="text-pretty">{labelTeam(teamIds)}</span>
+                                </div>
+                              );
+                            })}
                           </div>
                         </article>
                       ))}

--- a/src/app/matches/page.tsx
+++ b/src/app/matches/page.tsx
@@ -340,26 +340,20 @@ export default function MatchesPage() {
                                     <legend className="text-xs font-semibold uppercase tracking-[0.3em] text-[color:var(--muted)]">
                                       Choose side
                                     </legend>
-                                    <label className="flex items-center justify-between gap-3">
-                                      <span className="font-medium text-[color:var(--foreground)]">Team A</span>
-                                      <input
-                                        type="radio"
-                                        name={`winner-${match.id}`}
-                                        value="A"
-                                        checked={winner === "A"}
-                                        onChange={() => setWinner("A")}
-                                      />
-                                    </label>
-                                    <label className="flex items-center justify-between gap-3">
-                                      <span className="font-medium text-[color:var(--foreground)]">Team B</span>
-                                      <input
-                                        type="radio"
-                                        name={`winner-${match.id}`}
-                                        value="B"
-                                        checked={winner === "B"}
-                                        onChange={() => setWinner("B")}
-                                      />
-                                    </label>
+                                    {(["A", "B"] as const).map((side) => (
+                                      <label key={side} className="flex items-center justify-between gap-3">
+                                        <span className="font-medium text-[color:var(--foreground)]">
+                                          {match.is_doubles ? `Team ${side}` : side}
+                                        </span>
+                                        <input
+                                          type="radio"
+                                          name={`winner-${match.id}`}
+                                          value={side}
+                                          checked={winner === side}
+                                          onChange={() => setWinner(side)}
+                                        />
+                                      </label>
+                                    ))}
                                     <div className="flex flex-wrap items-center gap-3 pt-2">
                                       <button
                                         type="button"


### PR DESCRIPTION
## Summary
- update bracket match side labels to only use the "Team" prefix for doubles matchups
- mirror the new doubles/singles distinction on the Matches admin radio buttons

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e027fb0fd483328c55302dc35ff6be