### PR TITLE
Add global navigation bar and adjust brackets helper copy

### DIFF
--- a/src/app/brackets/page.tsx
+++ b/src/app/brackets/page.tsx
@@ -243,7 +243,7 @@ export default function BracketsPage() {
       )}
 
       <p className="text-center text-sm text-[color:var(--muted)]">
-        Tip: use the <Link href="/matches" className="underline">Matches</Link> page to set winners; updates appear instantly here.
+        Use the <Link href="/matches" className="underline">Matches</Link> page to set winners; updates appear instantly here.
       </p>
     </main>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import type { Metadata } from "next";
 import { Geist, Geist_Mono, Inter } from "next/font/google";
 import "./globals.css";
@@ -25,7 +26,51 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <body
         className={`${geistSans.variable} ${geistMono.variable} ${inter.className} bg-[var(--background)] text-[var(--foreground)] antialiased`}
       >
-        {children}
+        <div className="flex min-h-screen flex-col">
+          <header className="border-b border-[color:var(--border)] bg-[color:var(--background)]/90 backdrop-blur">
+            <nav className="mx-auto flex w-full max-w-5xl items-center justify-between gap-4 px-4 py-4 text-sm font-medium sm:px-6 lg:px-8">
+              <Link
+                href="/"
+                className="rounded-full border border-transparent px-3 py-1 text-[color:var(--foreground)] transition hover:border-[color:var(--border)] hover:bg-[color:var(--highlight)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--background)]"
+              >
+                Dinner with the Bishop
+              </Link>
+              <div className="flex flex-wrap items-center gap-2 sm:gap-3">
+                <Link
+                  href="/"
+                  className="rounded-full px-3 py-1 text-[color:var(--muted)] transition hover:bg-[color:var(--highlight)] hover:text-[color:var(--foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--background)]"
+                >
+                  Home
+                </Link>
+                <Link
+                  href="/brackets"
+                  className="rounded-full px-3 py-1 text-[color:var(--muted)] transition hover:bg-[color:var(--highlight)] hover:text-[color:var(--foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--background)]"
+                >
+                  Brackets
+                </Link>
+                <Link
+                  href="/matches"
+                  className="rounded-full px-3 py-1 text-[color:var(--muted)] transition hover:bg-[color:var(--highlight)] hover:text-[color:var(--foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--background)]"
+                >
+                  Matches
+                </Link>
+                <Link
+                  href="/players"
+                  className="rounded-full px-3 py-1 text-[color:var(--muted)] transition hover:bg-[color:var(--highlight)] hover:text-[color:var(--foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--background)]"
+                >
+                  Players
+                </Link>
+                <Link
+                  href="/control"
+                  className="rounded-full px-3 py-1 text-[color:var(--muted)] transition hover:bg-[color:var(--highlight)] hover:text-[color:var(--foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--background)]"
+                >
+                  TD Control
+                </Link>
+              </div>
+            </nav>
+          </header>
+          <div className="flex-1">{children}</div>
+        </div>
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- add a shared header navigation so every page links back to the home hub and primary views
- tweak the brackets helper text to more concisely direct users to the Matches page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e028e74d08833282d804f38433fecd