### PR TITLE
Fix admin seed swapping collision

### DIFF
--- a/src/app/players/page.tsx
+++ b/src/app/players/page.tsx
@@ -81,10 +81,16 @@ export default function PlayersPage() {
     }
 
     try {
-      await Promise.all([
-        adminFetch("/api/admin/players/update", { id: current.id, seed: neighbor.seed }),
-        adminFetch("/api/admin/players/update", { id: neighbor.id, seed: current.seed }),
-      ]);
+      await adminFetch("/api/admin/players/update", {
+        id: current.id,
+        seed: neighbor.seed,
+        allowSeedConflictWith: neighbor.id,
+      });
+      await adminFetch("/api/admin/players/update", {
+        id: neighbor.id,
+        seed: current.seed,
+        allowSeedConflictWith: current.id,
+      });
       await load();
       setMsg(`Moved ${current.name} ${direction === -1 ? "up" : "down"}.`);
     } catch (error: unknown) {


### PR DESCRIPTION
## Summary
- send swap updates sequentially from the admin players page so the first update completes before the partner moves
- allow the player update API to temporarily ignore conflicts with a designated partner during a swap to avoid false duplicate errors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3e23d00bc8332a0552ad92bd565f9