### PR TITLE
Update doubles tournament name

### DIFF
--- a/src/app/brackets/page.tsx
+++ b/src/app/brackets/page.tsx
@@ -23,7 +23,7 @@ type Player = { id: string; name: string };
 const BRACKET_TITLES: Record<Bracket, string> = {
   MAIN: "DwB Spring Champs",
   LOWER: "Pudel König",
-  DOUBLES: "Anthony Prangley Silence of the Champs",
+  DOUBLES: "Anthony Prangley Twin Bishops and Bar Bill",
 };
 
 const BRACKET_THEMES: Record<

--- a/src/app/matches/page.tsx
+++ b/src/app/matches/page.tsx
@@ -26,7 +26,7 @@ type Player = { id: string; name: string; seed: number | null };
 const BRACKET_TITLES: Record<Bracket, string> = {
   MAIN: "DwB Spring Champs",
   LOWER: "Pudel König",
-  DOUBLES: "Anthony Prangley Silence of the Champs",
+  DOUBLES: "Anthony Prangley Twin Bishops and Bar Bill",
 };
 
 const BRACKET_THEMES: Record<


### PR DESCRIPTION
## Summary
- rename the doubles bracket title to "Anthony Prangley Twin Bishops and Bar Bill" across admin and public pages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6369551688332a646d27068fbead6